### PR TITLE
Landscaper unit tests

### DIFF
--- a/src/group10player/Landscaper.java
+++ b/src/group10player/Landscaper.java
@@ -198,29 +198,31 @@ public class Landscaper extends Unit{
         for (Direction dir: directions){
             dontDig = false;
             adjLocation = rc.adjacentLocation(dir);
-            if (!rc.canSenseLocation(adjLocation)){
-                System.out.println("My location is "+rc.getLocation().toString()+", I'm failing to see "+rc.adjacentLocation(dir).toString());
-                continue;
-            }
-            if (!adjLocation.isAdjacentTo(HQLocation)/* && dir != directionFlooded*/) {
-                for (Direction dir2: directions) {
-                    if (!rc.canSenseLocation(adjLocation.add(dir2))){
-                        System.out.println("My location is "+rc.getLocation().toString()+", I'm failing to see "+adjLocation.add(dir2).toString());
-                        continue;
-                    }
-                    if (rc.senseFlooding(adjLocation.add(dir2))) {
-                        dontDig = true; //don't dig if tile is adjacent to water
-                        break;
-                    }
-                    if (adjLocation.distanceSquaredTo(HQLocation) <= 8){
-                        dontDig = true; //don't dig from tiles within 2 tiles of HQ
-                        break;
-                    }
+            if(adjLocation != null) {
+                if (!rc.canSenseLocation(adjLocation)) {
+                    System.out.println("My location is " + rc.getLocation().toString() + ", I'm failing to see " + rc.adjacentLocation(dir).toString());
+                    continue;
                 }
-                int dirElevation = rc.senseElevation(adjLocation);
-                if (dirElevation > maxElevationAround && !dontDig && rc.canDigDirt(dir)){
-                    maxElevationAround = dirElevation;
-                    maxElevationDir = dir;
+                if (!adjLocation.isAdjacentTo(HQLocation)/* && dir != directionFlooded*/) {
+                    for (Direction dir2 : directions) {
+                        if (!rc.canSenseLocation(adjLocation.add(dir2))) {
+                            System.out.println("My location is " + rc.getLocation().toString() + ", I'm failing to see " + adjLocation.add(dir2).toString());
+                            continue;
+                        }
+                        if (rc.senseFlooding(adjLocation.add(dir2))) {
+                            dontDig = true; //don't dig if tile is adjacent to water
+                            break;
+                        }
+                        if (adjLocation.distanceSquaredTo(HQLocation) <= 8) {
+                            dontDig = true; //don't dig from tiles within 2 tiles of HQ
+                            break;
+                        }
+                    }
+                    int dirElevation = rc.senseElevation(adjLocation);
+                    if (dirElevation >= maxElevationAround && !dontDig && rc.canDigDirt(dir)) {
+                        maxElevationAround = dirElevation;
+                        maxElevationDir = dir;
+                    }
                 }
             }
         }

--- a/src/group10player/Landscaper.java
+++ b/src/group10player/Landscaper.java
@@ -138,16 +138,17 @@ public class Landscaper extends Unit{
     //Look for HQ, update directionHQ
     public boolean findHQ() throws GameActionException{
         if (HQLocation == null){
-            tryFindHQLocation();
-            walkRandom();
-            return false;
+            if(!tryFindHQLocation()) {
+                walkRandom();
+                return false;
+            }
         }
         int minElevation = 1000;
         MapLocation verifyLocation;
         for (Direction dir: directions){
             //if(rc.canMove(dir)){
             verifyLocation = rc.adjacentLocation(dir);
-            if(verifyLocation.isAdjacentTo(HQLocation)){
+            if(verifyLocation != null && verifyLocation.isAdjacentTo(HQLocation)){
                 if (rc.canSenseLocation(verifyLocation) && rc.senseElevation(verifyLocation) >= wallHeight){  //only raise wall to 10 high for now
                     continue;
                 }

--- a/src/group10player/Landscaper.java
+++ b/src/group10player/Landscaper.java
@@ -253,6 +253,15 @@ public class Landscaper extends Unit{
         return false;
     }
 
+    //helper function to allow setting myElevationToInt
+    public void setMyElevation(int num){
+        myElevation = num;
+    }
+    //helper function to allow setting mySensorRadius
+    public void setMySensorRadius(int num){
+        mySensorRadius = num;
+    }
+
 }
 
 

--- a/src/group10player/Robot.java
+++ b/src/group10player/Robot.java
@@ -4,7 +4,7 @@ import battlecode.common.*;
 
 //Robot will receive "rc" as a variable in its constructor.
 public class Robot {
-    RobotController rc;
+    public RobotController rc;
 
     Team myTeam;
 
@@ -87,6 +87,15 @@ public class Robot {
             }
         }
         return false;
+    }
+
+    //allows robot to update their location after being constructed
+    public void setMyLocation(){
+        myLocation = rc.getLocation();
+    }
+    //allws robot to update their team after being constructed
+    public void setMyTeam(){
+        myTeam = rc.getTeam();
     }
 
 

--- a/src/group10player/Robot.java
+++ b/src/group10player/Robot.java
@@ -93,6 +93,10 @@ public class Robot {
     public void setMyLocation(){
         myLocation = rc.getLocation();
     }
+    //allows robot to update HqLocation
+    public void setHqLocation(MapLocation hq){
+        HQLocation = hq;
+    }
     //allows robot to update their team after being constructed
     public void setMyTeam(){
         myTeam = rc.getTeam();

--- a/src/group10player/Robot.java
+++ b/src/group10player/Robot.java
@@ -93,9 +93,13 @@ public class Robot {
     public void setMyLocation(){
         myLocation = rc.getLocation();
     }
-    //allws robot to update their team after being constructed
+    //allows robot to update their team after being constructed
     public void setMyTeam(){
         myTeam = rc.getTeam();
+    }
+    //allows robot to update their HQ elevation used for testing
+    public void setHQElevation(int num){
+        initialHQElevation = 2;
     }
 
 

--- a/test/group10playertest/LandscaperTest.java
+++ b/test/group10playertest/LandscaperTest.java
@@ -65,9 +65,65 @@ public class LandscaperTest {
         //set Landscaper sensor radius
         LStest.setMySensorRadius(sensorRadius);
 
-        //test findHQ, expect True is returned
+        //test canDig, expect True is returned
         boolean found = LStest.findHQ();
         assertTrue(found);
 
     }
+
+
+    @Test
+    public void digIfYouCanCanDig() throws GameActionException {
+        MapLocation lsLocation = new MapLocation(5,5);
+        MapLocation hqLocation = new MapLocation(17,17);
+        MapLocation adjacent = new MapLocation(7,7);
+        int elevation = 5;
+        int sensorRadius = 24;
+
+        //setHQLocation
+        LStest.setHqLocation(hqLocation);
+
+        //set Landscaper sensor radius
+        LStest.setMySensorRadius(sensorRadius);
+
+        //set Landscaper location
+        when(RCtest.getLocation()).thenReturn(lsLocation);
+        LStest.setMyLocation();
+
+        //set Landscaper can move true if northwest
+        when(RCtest.canMove(Direction.NORTHEAST)).thenReturn(true);
+        //set Landscaper isAdjacentDirection
+        when(RCtest.adjacentLocation(Direction.NORTHEAST)).thenReturn(adjacent);
+
+        //set Landscaper elevation sensed equal to 5 to allow for HQ Locating
+        when(RCtest.senseElevation(adjacent)).thenReturn(elevation);
+        when(RCtest.canSenseLocation(adjacent)).thenReturn(true);
+        when(RCtest.canSenseLocation(adjacent.add(Direction.SOUTH))).thenReturn(true);
+        LStest.setMyElevation(elevation);
+
+        //Landscaper can dig to south
+        when(RCtest.canDigDirt(Direction.SOUTH)).thenReturn(true);
+        when(RCtest.canDigDirt(Direction.NORTHEAST)).thenReturn(true);
+
+        //test digIfYouCan, expect True is returned
+        boolean found = LStest.digIfYouCan();
+        assertTrue(found);
+
+    }
+
+    @Test
+    public void dropDirtIfYouCan() throws GameActionException {
+        Direction toDrop = Direction.NORTHEAST;
+
+        when(RCtest.canDepositDirt(toDrop)).thenReturn(true);
+
+        //test dropIfYouCan, expect True is returned
+        boolean found = LStest.dropDirtIfYouCan(toDrop);
+        assertTrue(found);
+
+    }
+
+
+
+
 }

--- a/test/group10playertest/LandscaperTest.java
+++ b/test/group10playertest/LandscaperTest.java
@@ -3,12 +3,10 @@ package group10playertest;
 import battlecode.common.*;
 import group10player.Landscaper;
 import group10player.RobotPlayer;
-import group10player.Robot;
 import battlecode.common.RobotController;
-import group10player.Unit;
 import org.junit.*;
 import org.mockito.*;
-import org.scalactic.Or;
+
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -115,6 +113,7 @@ public class LandscaperTest {
     public void dropDirtIfYouCan() throws GameActionException {
         Direction toDrop = Direction.NORTHEAST;
 
+        //return true if testing if can drop
         when(RCtest.canDepositDirt(toDrop)).thenReturn(true);
 
         //test dropIfYouCan, expect True is returned
@@ -122,6 +121,40 @@ public class LandscaperTest {
         assertTrue(found);
 
     }
+
+    @Test
+    public void checkWallFinished() throws GameActionException {
+        MapLocation hqLocation = new MapLocation(17,17);
+        int elevation = 5;
+        int sensorRadius = 24;
+
+        //setHQLocation
+        LStest.setHqLocation(hqLocation);
+
+        //set up HQ wall test
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.SOUTH))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.SOUTHEAST))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.SOUTHWEST))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.NORTH))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.NORTHWEST))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.NORTHEAST))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.EAST))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.WEST))).thenReturn(true);
+
+        when(RCtest.senseElevation(hqLocation.add(Direction.SOUTH))).thenReturn(10);
+        when(RCtest.senseElevation(hqLocation.add(Direction.SOUTHEAST))).thenReturn(10);
+        when(RCtest.senseElevation(hqLocation.add(Direction.SOUTHWEST))).thenReturn(10);
+        when(RCtest.senseElevation(hqLocation.add(Direction.NORTH))).thenReturn(10);
+        when(RCtest.senseElevation(hqLocation.add(Direction.NORTHWEST))).thenReturn(10);
+        when(RCtest.senseElevation(hqLocation.add(Direction.NORTHEAST))).thenReturn(10);
+        when(RCtest.senseElevation(hqLocation.add(Direction.EAST))).thenReturn(10);
+        when(RCtest.senseElevation(hqLocation.add(Direction.WEST))).thenReturn(10);
+
+        //test wallFinished, expect True is returned
+        boolean found = LStest.checkWallFinished();
+        assertTrue(found);
+    }
+
 
 
 

--- a/test/group10playertest/LandscaperTest.java
+++ b/test/group10playertest/LandscaperTest.java
@@ -125,9 +125,6 @@ public class LandscaperTest {
     @Test
     public void checkWallFinished() throws GameActionException {
         MapLocation hqLocation = new MapLocation(17,17);
-        int elevation = 5;
-        int sensorRadius = 24;
-
         //setHQLocation
         LStest.setHqLocation(hqLocation);
 
@@ -155,8 +152,36 @@ public class LandscaperTest {
         assertTrue(found);
     }
 
+    @Test
+    public void checkWallNotFinished() throws GameActionException {
+        MapLocation hqLocation = new MapLocation(17,17);
 
+        //setHQLocation
+        LStest.setHqLocation(hqLocation);
 
+        //set up HQ wall test
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.SOUTH))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.SOUTHEAST))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.SOUTHWEST))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.NORTH))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.NORTHWEST))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.NORTHEAST))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.EAST))).thenReturn(true);
+        when(RCtest.canSenseLocation(hqLocation.add(Direction.WEST))).thenReturn(true);
+
+        when(RCtest.senseElevation(hqLocation.add(Direction.SOUTH))).thenReturn(10);
+        when(RCtest.senseElevation(hqLocation.add(Direction.SOUTHEAST))).thenReturn(7);
+        when(RCtest.senseElevation(hqLocation.add(Direction.SOUTHWEST))).thenReturn(10);
+        when(RCtest.senseElevation(hqLocation.add(Direction.NORTH))).thenReturn(10);
+        when(RCtest.senseElevation(hqLocation.add(Direction.NORTHWEST))).thenReturn(10);
+        when(RCtest.senseElevation(hqLocation.add(Direction.NORTHEAST))).thenReturn(10);
+        when(RCtest.senseElevation(hqLocation.add(Direction.EAST))).thenReturn(8);
+        when(RCtest.senseElevation(hqLocation.add(Direction.WEST))).thenReturn(10);
+
+        //test wallFinished, expect False is returned
+        boolean found = LStest.checkWallFinished();
+        assertFalse(found);
+    }
 
 
 }

--- a/test/group10playertest/LandscaperTest.java
+++ b/test/group10playertest/LandscaperTest.java
@@ -3,12 +3,14 @@ package group10playertest;
 import battlecode.common.*;
 import group10player.Landscaper;
 import group10player.RobotPlayer;
+import group10player.Robot;
+import battlecode.common.RobotController;
+import group10player.Unit;
 import org.junit.*;
 import org.mockito.*;
 import org.scalactic.Or;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
 public class LandscaperTest {
@@ -21,13 +23,51 @@ public class LandscaperTest {
     public void beforeEachTest() throws GameActionException {
         RCtest = Mockito.mock(RobotController.class);
         RPtest = Mockito.mock(RobotPlayer.class);
-        //LStest = new Landscaper(RCtest);
+        LStest = new Landscaper(RCtest);
     }
 
     @Test
     public void taketurntest() throws GameActionException {
-        MapLocation temp = new MapLocation(1,1);
-        when(RCtest.getLocation()).thenReturn(temp);
-        //LStest.takeTurn();
+        LStest.takeTurn();
+    }
+
+    @Test
+    public void findHQTest() throws GameActionException {
+        MapLocation lsLocation = new MapLocation(5,5);
+        MapLocation hqLocation = new MapLocation(7,7);
+        MapLocation adjacent = new MapLocation(6,6);
+        RobotInfo hqInfo = new RobotInfo(1, Team.B,RobotType.HQ,-1,false,-1, -1, -1, hqLocation);
+        RobotInfo[] nearByRobots = {hqInfo};
+        int elevation = 5;
+        int sensorRadius = 24;
+
+        //allow Landscaper to detect a nearby Robot that is HQ
+        when(RCtest.senseNearbyRobots()).thenReturn(nearByRobots);
+
+        //set Landscaper team to match HQ
+        when(RCtest.getTeam()).thenReturn(Team.B);
+        LStest.setMyTeam();
+
+        //set Landscaper location
+        when(RCtest.getLocation()).thenReturn(lsLocation);
+        LStest.setMyLocation();
+
+        //set Landscaper can move true if northwest
+        when(RCtest.canMove(Direction.NORTHEAST)).thenReturn(true);
+        //set Landscaper isAdjacentDirection
+        when(RCtest.adjacentLocation(Direction.NORTHEAST)).thenReturn(adjacent);
+
+        //set Landscaper elevation sensed equal to 5 to allow for HQ Locating
+        when(RCtest.senseElevation(adjacent)).thenReturn(elevation);
+        when(RCtest.canSenseLocation(adjacent)).thenReturn(true);
+        LStest.setMyElevation(elevation);
+
+        //set Landscaper sensor radius
+        LStest.setMySensorRadius(sensorRadius);
+
+        //test findHQ, expect True is returned
+        boolean found = LStest.findHQ();
+        assertTrue(found);
+
     }
 }


### PR DESCRIPTION
Adds landscaper unit tests, some helper functions for manually updating attributes of robots and landscapers, and fixes a couple bugs I found in landscaper while testing (could have a null pointer when verifying adjacent location) and  issue in line 141 where we would exit the function as false even if we actually found HQ. 